### PR TITLE
remove sudo command with root user

### DIFF
--- a/setup/1_prepare.sh
+++ b/setup/1_prepare.sh
@@ -10,7 +10,7 @@ if [ "$DISTRO" == "redhat" ]; then
     yum -y install gcc python36 python36-devel postgresql supervisor
     python36 -m ensurepip
 elif [ "$DISTRO" == "ubuntu" ]; then
-    sudo apt-add-repository universe
+    apt-add-repository universe
     # apt-get update
     apt-get install -y python3 python3-setuptools python3-pip gcc postgresql supervisor
 fi


### PR DESCRIPTION
During the step 1 (prepare) of the setup and all the time during the setup we doesn't  use sudo except for the postgresql commands who need to be runned by the postgres user, so I remove the usage of sudo used during the adding of universe repository on ubuntu.