### PR TITLE
Improved readability of generated docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ Automation, "DevOps", Etc
 
 Projects in Vespene don't need to just represent source code. Projects can also launch automation scripts or software of any kind, whether being pulled from source control or just scripts defined in Vespene. These jobs can include security scans, cloud topology changes, database backups, launching functional tests, and more.
 
-While not all automation tools are SSH-powered, many are. Vespene can memorize important :ref:`ssh` keys and use them on your behalf, using built-in support for ssh-agent.
+While not all automation tools are SSH-powered, many are. Vespene can memorize important :ref:`ssh` and use them on your behalf, using built-in support for ssh-agent.
 
 Helping with the self-service magic, projects can ask interactive questions before they are launched with :ref:`launch_questions`, providing unprivileged users a simple interface to invoke specific tasks without needing full shell access. These questions can be drop-downs, multiple choice, or fill in the blank.
 

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -212,7 +212,7 @@ One minor gotcha is that we didn't know in advance if you wanted to install the 
 same box as the Vespene services, so the Vespene services don't normally have a startup dependency on the
 database.  You can add this by editing the systemd unit file.
 
-If the service is not operational on reboot because PostgreSQL was not ready, just restart "vespene.service".
+If the service is not operational on reboot because PostgreSQL was not ready, just restart "vespene.service" using "systemctl restart vespene.serve".
 
 Developers can learn about starting workers and the web process in :ref:`development_setup` and many systems
 administrators will also benefit from understanding this as well. In short, supervisord runs and watches over

--- a/docs/source/workers.rst
+++ b/docs/source/workers.rst
@@ -44,8 +44,8 @@ as templated through the :ref:`variables` system.
 Platform Support
 ----------------
 
-It is important to note that the builders have been developed for OS X, *BSD, and Linux operating systems, and have not been tested on windows at this
-point. We openly welcome community contributions for windows builder support.  This will probably require some *very minor*
+It is important to note that the builders have been developed for *OS X, BSD, and Linux operating systems, and have not been tested on windows at this
+point*. We openly welcome community contributions for windows builder support.  This will probably require some *very minor*
 changes to add a new isolation mode, which is discussed below. Let's talk about this on the forum!
 
 .. _worker_pools:
@@ -96,9 +96,9 @@ they can do anything, but they do run from the worker machines.
 
 A working directory is then prepared using the build root configured in settings.py, named after the build number.
 
-The worker will then add any :ref:`ssh` keys associated with the project before running the build.
+The worker will then add any :ref:`ssh` associated with the project before running the build.
 
-The worker will then perform any source control checkouts using any :ref:`service_logins` or :ref:`ssh` keys,
+The worker will then perform any source control checkouts using any :ref:`service_logins` or :ref:`ssh`,
 but not all build scripts are required to have a repo associated with them.  They could just run a simple script
 without a checkout (if the project SCM type is set to "none").
 
@@ -157,7 +157,7 @@ Sudo Isolation
 ==============
 
 The first mode, sudo, switches to a sudo user before running the build script.  This mode comes with few dependencies and is easy
-to set up. On the worker pool, the sudo_user must be configured, and this user as described in :ref:`security` must NOT
+to set up. On the worker pool, the sudo_user must be configured, and this user as described in the :ref:`security` must NOT
 have access to read the Vespene configuration files.
 
 .. _container_isolation:


### PR DESCRIPTION
removed duplicates of the word 'keys' in the final documentation introduced by the way `ssh` is called in the rst.