### PR TITLE
New setup

### DIFF
--- a/setup/0_common.sh
+++ b/setup/0_common.sh
@@ -2,9 +2,21 @@
 # /etc/vespene/settings.d/database.py info
 # --
 
-# Please change these settings!
+# Database configuration
+# the local database is fine for an initial deployment
+# be sure to change the password!
 DBSERVER="127.0.0.1"
 DBPASS="vespene!"
+
+# --
+# webserver info
+# --
+
+# options to feed to gunicorn in /etc/vespene/supervisord.conf
+# if you change this to 0.0.0.0 to bind to all addresses be
+# sure to set up SSL
+
+GUNICORN_OPTS = "--bind 127.0.0.1:8000"
 
 # --
 # /etc/vespene/settings.d/build.py info
@@ -16,12 +28,9 @@ BUILDROOT="/tmp/vespene"
 # /etc/vespene/supervisord.conf info
 # ---
 
-# Should this machine be running the Vespene webUI?
-IS_CONTROLLER="true"
-
-# Should this machine be running any workers, this is a space separated 
-# string of key=value pairs where the name is a worker pool name 
-# (configured in the Vespene UI) and the value is the number of copies 
+# Should this machine be running any workers? 
+# This is a space separated string of key=value pairs where the name is a 
+# worker pool name (configured in the Vespene UI) and the value is the number of copies 
 # of that worker to run. Increasing the number increases parallelism.
 
 # WORKER_CONFIG="general=2 tutorial-pool=1"

--- a/setup/0_common.sh
+++ b/setup/0_common.sh
@@ -36,25 +36,45 @@ BUILDROOT="/tmp/vespene"
 # WORKER_CONFIG="general=2 tutorial-pool=1"
 WORKER_CONFIG="tutorial-pool=1"
 
+# how do you need to sudo to run the python management commands?
+APP_SUDO="sudo"
+
+# how do you need to sudo to run postgresql management commands?
+POST_SUDO="sudo -u postgres"
+
+# what filesystem user should own the postgresql data directory?
+DB_USER="postgres"
+
+# what user should be running Vespene itself?
+APP_USER="vespene"
+
 # rough OS detection for now; patches accepted!
 if [ "$OSTYPE" == "linux-gnu" ]; then
    if [ -f /etc/redhat-release ]; then
+      echo "detected RHEL/CentOS"
       DISTRO="redhat"
       PIP="/usr/local/bin/pip3.6"
       PYTHON="/usr/bin/python3.6"
    elif [ -f /usr/bin/apt ]; then
+      echo "detected Ubuntu/Debian"
       DISTRO="ubuntu"
       PYTHON="/usr/bin/python3"
       PIP="/usr/bin/pip3"
    elif [ -f /usr/bin/pacman ]; then
+      echo "detected Arch"
       DISTRO="archlinux"
       PYTHON="/usr/bin/python"
       PIP="/usr/bin/pip"
    fi
 elif [ -f /usr/local/bin/brew ]; then
+      echo "detected MacOS"
       DISTRO="MacOS"
       PYTHON="/usr/local/bin/python3"
       PIP="/usr/local/bin/pip3"
+      APP_SUDO=""
+      POST_SUDO=""
+      DB_USER=`whoami`
+      APP_USER=`whoami`
 else
    echo "this OS may work with Vespene but we don't have setup automation for this just yet"
    DISTRO="?"

--- a/setup/0_common.sh
+++ b/setup/0_common.sh
@@ -16,7 +16,7 @@ DBPASS="vespene!"
 # if you change this to 0.0.0.0 to bind to all addresses be
 # sure to set up SSL
 
-GUNICORN_OPTS = "--bind 127.0.0.1:8000"
+GUNICORN_OPTS="--bind 127.0.0.1:8000"
 
 # --
 # /etc/vespene/settings.d/build.py info
@@ -51,6 +51,10 @@ if [ "$OSTYPE" == "linux-gnu" ]; then
       PYTHON="/usr/bin/python"
       PIP="/usr/bin/pip"
    fi
+elif [ -f /usr/local/bin/brew ]; then
+      DISTRO="MacOS"
+      PYTHON="/usr/local/bin/python3"
+      PIP="/usr/local/bin/pip3"
 else
    echo "this OS may work with Vespene but we don't have setup automation for this just yet"
    DISTRO="?"

--- a/setup/0_common.sh
+++ b/setup/0_common.sh
@@ -33,6 +33,8 @@ BUILDROOT="/tmp/vespene"
 # worker pool name (configured in the Vespene UI) and the value is the number of copies 
 # of that worker to run. Increasing the number increases parallelism.
 
+DISTRO="?"
+
 # WORKER_CONFIG="general=2 tutorial-pool=1"
 WORKER_CONFIG="tutorial-pool=1"
 

--- a/setup/0_common.sh
+++ b/setup/0_common.sh
@@ -51,7 +51,7 @@ DB_USER="postgres"
 APP_USER="vespene"
 
 # rough OS detection for now; patches accepted!
-if [ "$OSTYPE" == "linux-gnu" ]; then
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
    if [ -f /etc/redhat-release ]; then
       echo "detected RHEL/CentOS"
       DISTRO="redhat"
@@ -80,4 +80,10 @@ elif [ -f /usr/local/bin/brew ]; then
 else
    echo "this OS may work with Vespene but we don't have setup automation for this just yet"
    DISTRO="?"
+fi
+
+me=`whoami`
+if [[ "$m1e" == "root" ]]; then
+    echo "*** please re-run this script from a user account with sudo rights"
+    exit 1
 fi

--- a/setup/1_prepare.sh
+++ b/setup/1_prepare.sh
@@ -15,6 +15,8 @@ elif [ "$DISTRO" == "ubuntu" ]; then
     apt-get install -y gcc libssl-dev postgresql-client python3 python3-pip python3-setuptools supervisor
 elif [ "$DISTRO" == "archlinux" ]; then
     pacman --noconfirm -Sy python python-pip python-setuptools postgresql supervisor sudo
+elif [ "$DISTRO" == "MacOS" ]; then
+    brew install python@3 postgresql supervisor
 fi
 
 echo "Setting up directories..."

--- a/setup/1_prepare.sh
+++ b/setup/1_prepare.sh
@@ -34,6 +34,7 @@ echo "Cloning the project into /opt/vespene..."
 rm -rf /opt/vespene/*
 sudo cp -a ../* /opt/vespene
 
+echo "APP_USER=$APP_USER"
 sudo chown -R $APP_USER /opt/vespene
 sudo chown -R $APP_USER /var/spool/vespene
 sudo chown -R $APP_USER /etc/vespene/settings.d/

--- a/setup/1_prepare.sh
+++ b/setup/1_prepare.sh
@@ -6,29 +6,40 @@ echo "PIP=$PIP"
 
 echo "Installing core packages..."
 if [ "$DISTRO" == "redhat" ]; then
-    yum -y install epel-release
-    yum -y install gcc python36 python36-devel postgresql supervisor
-    python36 -m ensurepip
+    sudo yum -y install epel-release
+    sudo yum -y install gcc python36 python36-devel postgresql supervisor
+    sudo python36 -m ensurepip
 elif [ "$DISTRO" == "ubuntu" ]; then
-    apt-add-repository universe
-    apt-get update
-    apt-get install -y gcc libssl-dev postgresql-client python3 python3-pip python3-setuptools supervisor
+    sudo apt-add-repository universe
+    sudo apt-get update
+    sudo apt-get install -y gcc libssl-dev postgresql-client python3 python3-pip python3-setuptools supervisor
 elif [ "$DISTRO" == "archlinux" ]; then
-    pacman --noconfirm -Sy python python-pip python-setuptools postgresql supervisor sudo
+    sudo pacman --noconfirm -Sy python python-pip python-setuptools postgresql supervisor sudo
 elif [ "$DISTRO" == "MacOS" ]; then
     brew install python@3 postgresql supervisor
 fi
 
+if [ "$DISTRO" != "MacOS" ]; then
+    adduser vespene
+fi
+
 echo "Setting up directories..."
 
-mkdir -p /opt/vespene
-mkdir -p /var/spool/vespene
-mkdir -p /etc/vespene/settings.d/
+sudo mkdir -p /opt/vespene
+sudo mkdir -p /var/spool/vespene
+sudo mkdir -p /etc/vespene/settings.d/
+sudo mkdir -p /var/log/vespene/
 
 echo "Cloning the project into /opt/vespene..."
-git clone https://github.com/vespene-io/vespene.git /opt/vespene
+rm -rf /opt/vespene/*
+sudo cp -a ../* /opt/vespene
+
+sudo chown -R $APP_USER /opt/vespene
+sudo chown -R $APP_USER /var/spool/vespene
+sudo chown -R $APP_USER /etc/vespene/settings.d/
+sudo chown -R $APP_USER /var/log/vespene
 
 echo "Installing python packages..."
-CMD="$PYTHON -m pip install -r ../requirements.txt --trusted-host pypi.org --trusted-host files.pypi.org --trusted-host files.pythonhosted.org"
+CMD="sudo $PYTHON -m pip install -r ../requirements.txt --trusted-host pypi.org --trusted-host files.pypi.org --trusted-host files.pythonhosted.org"
 echo $CMD
 $CMD

--- a/setup/1_prepare.sh
+++ b/setup/1_prepare.sh
@@ -20,7 +20,7 @@ elif [ "$DISTRO" == "MacOS" ]; then
 fi
 
 if [ "$DISTRO" != "MacOS" ]; then
-    adduser vespene
+    sudo adduser vespene
 fi
 
 echo "Setting up directories..."

--- a/setup/2_database.sh
+++ b/setup/2_database.sh
@@ -34,7 +34,7 @@ if [[ "$DISTRO" == "archlinux" ]]; then
 elif [[ "$DISTRO" == "MacOS" ]]; then
     initdb /usr/local/var/postgres
 elif [[ "$DISTRO" == "redhat" ]]; then
-    echo "FIXME: initdb?"
+    sudo -u postgres postgresql-setup initdb
 else
     echo "initdb should not be needed on this platform"
 fi

--- a/setup/2_database.sh
+++ b/setup/2_database.sh
@@ -8,6 +8,12 @@
 # load common settings
 source ./0_common.sh
 
+if [ "$DISTRO" == "MacOS" ]; then
+   POSTUSER="_postgres"
+else
+   POSTUSER="postgres"
+fi
+
 echo "installing packages..."
 # install postgresql
 if [[ "$DISTRO" == "redhat" ]]; then
@@ -18,13 +24,17 @@ elif [[ "$IDSTRO" == "ubuntu" ]]; then
    CONFIG="/etc/postgresql/10/main/pg_hba.conf"
 elif [[ "$DISTRO" == "archlinux" ]]; then
    CONFIG="/var/lib/postgres/data/pg_hba.conf"
+elif [[ "$DISTRO" == "MacOS" ]]; then
+    CONFIG="/usr/local/var/postgres/pg_hba.conf"
 fi
 
 echo "initializing the database server..."
 if [[ "$DISTRO" == "archlinux" ]]; then
-    sudo -u postgres initdb -D '/var/lib/postgres/data'
+    sudo -u $POSTUSER initdb -D '/var/lib/postgres/data'
+elif [[ "$DISTRO" == "MacOS" ]]; then
+    sudo -u $POSTUSER initdb /usr/local/var/postgres
 else
-    sudo -u postgres postgresql-setup initdb
+    sudo -u $POSTUSER postgresql-setup initdb
 fi
 
 echo "configuring security..."
@@ -33,28 +43,35 @@ echo "configuring security..."
 # that will work with the /etc/vespene/settings.d/database.py that will be created.
 # Using password auth is highly recommended as the workers also use database access.
 cat > "$CONFIG" <<'END_OF_CONF'
-local	all	postgres	ident
+local	all	$POSTUSER	ident
+local	all	$POSTUSER	md5
 host	all	all	0.0.0.0/0	md5
 END_OF_CONF
 
 echo "starting postgresql..."
+if [ "$OSTYPE" == "linux-gnu" ]; then
 # start the PostgreSQL service using systemd
-systemctl enable postgresql.service
-systemctl start postgresql.service
+    systemctl enable postgresql.service
+    systemctl start postgresql.service
+elif [ "$DISTRO" == "MacOS" ]; then
+    sudo -u $POSTUSER brew services start postgresql
+fi
+
 
 echo "creating the vespene database and user..."
 echo "  (if you any errors from 'cd' here or further down they can be ignored)"
 
-EXISTS=`sudo -u postgres psql -lqt | grep vespene`
+EXISTS=`sudo -u $POSTUSER psql -lqt | grep vespene`
 if [ $? -eq 1 ]; then
-   sudo -u postgres createdb vespene
+   sudo -u $POSTUSER createdb vespene
    echo "creating the vespene user"
-   sudo -u postgres createuser vespene
+   sudo -u $POSTUSER createuser vespene
 else
    echo "- database already exists"
 fi
 
+
 echo "granting access..."
 # give the user access and set their password
-sudo -u postgres psql -U postgres -d vespene -c "GRANT ALL on DATABASE vespene TO vespene"
-sudo -u postgres psql -U postgres -d vespene -c "ALTER USER vespene WITH ENCRYPTED PASSWORD '$DBPASS'"
+sudo -u $POSTUSER psql -U postgres -d vespene -c "GRANT ALL on DATABASE vespene TO vespene"
+sudo -u $POSTUSER psql -U postgres -d vespene -c "ALTER USER vespene WITH ENCRYPTED PASSWORD '$DBPASS'"

--- a/setup/2_database.sh
+++ b/setup/2_database.sh
@@ -8,70 +8,72 @@
 # load common settings
 source ./0_common.sh
 
-if [ "$DISTRO" == "MacOS" ]; then
-   POSTUSER="_postgres"
-else
-   POSTUSER="postgres"
-fi
-
+# ---
 echo "installing packages..."
 # install postgresql
 if [[ "$DISTRO" == "redhat" ]]; then
-   yum -y install postgresql-server
+   sudo yum -y install postgresql-server
    CONFIG="/var/lib/pgsql/data/pg_hba.conf"
 elif [[ "$IDSTRO" == "ubuntu" ]]; then
-   apt install -y postgresql postgresql-contrib
+   sudo apt install -y postgresql postgresql-contrib
    CONFIG="/etc/postgresql/10/main/pg_hba.conf"
 elif [[ "$DISTRO" == "archlinux" ]]; then
+   sudo pacman --noconfirm -Sy postgresql
    CONFIG="/var/lib/postgres/data/pg_hba.conf"
 elif [[ "$DISTRO" == "MacOS" ]]; then
-    CONFIG="/usr/local/var/postgres/pg_hba.conf"
+   CONFIG="/usr/local/var/postgres/pg_hba.conf"
 fi
 
+# ---
 echo "initializing the database server..."
+
 if [[ "$DISTRO" == "archlinux" ]]; then
-    sudo -u $POSTUSER initdb -D '/var/lib/postgres/data'
+    sudo -u postgres initdb -D '/var/lib/postgres/data'
 elif [[ "$DISTRO" == "MacOS" ]]; then
-    sudo -u $POSTUSER initdb /usr/local/var/postgres
+    initdb /usr/local/var/postgres
 else
-    sudo -u $POSTUSER postgresql-setup initdb
+    sudo -u postgres postgresql-setup initdb
 fi
 
-echo "configuring security..."
+# ----
+echo "configuring security at $CONFIG..."
+
 # configure PostgreSQL security to allow the postgres account in locally, and allow
 # password access remotely.  You can tweak this if you want but must choose something
 # that will work with the /etc/vespene/settings.d/database.py that will be created.
 # Using password auth is highly recommended as the workers also use database access.
-cat > "$CONFIG" <<'END_OF_CONF'
-local	all	$POSTUSER	ident
-local	all	$POSTUSER	md5
+sudo tee -a $CONFIG > /dev/null <<END_OF_CONF
+local	all	${DB_USER}	ident
 host	all	all	0.0.0.0/0	md5
 END_OF_CONF
 
+chown $DB_USER $CONFIG
+
+# ---
 echo "starting postgresql..."
 if [ "$OSTYPE" == "linux-gnu" ]; then
 # start the PostgreSQL service using systemd
-    systemctl enable postgresql.service
-    systemctl start postgresql.service
+    sudo systemctl enable postgresql.service
+    sudo systemctl start postgresql.service
 elif [ "$DISTRO" == "MacOS" ]; then
-    sudo -u $POSTUSER brew services start postgresql
+    /usr/local/bin/pg_ctl restart -D /usr/local/var/postgres/
 fi
 
-
+# --
 echo "creating the vespene database and user..."
 echo "  (if you any errors from 'cd' here or further down they can be ignored)"
 
-EXISTS=`sudo -u $POSTUSER psql -lqt | grep vespene`
+EXISTS=`sudo -u $DB_USER psql -lqt | grep vespene`
 if [ $? -eq 1 ]; then
-   sudo -u $POSTUSER createdb vespene
+   $POST_SUDO createdb vespene
    echo "creating the vespene user"
-   sudo -u $POSTUSER createuser vespene
+   $POST_SUDO createuser vespene
 else
    echo "- database already exists"
 fi
 
-
+# --
 echo "granting access..."
 # give the user access and set their password
-sudo -u $POSTUSER psql -U postgres -d vespene -c "GRANT ALL on DATABASE vespene TO vespene"
-sudo -u $POSTUSER psql -U postgres -d vespene -c "ALTER USER vespene WITH ENCRYPTED PASSWORD '$DBPASS'"
+$POST_SUDO psql -d vespene -c "GRANT ALL on DATABASE vespene TO vespene"
+$POST_SUDO psql -d vespene -c "ALTER USER vespene WITH ENCRYPTED PASSWORD '$DBPASS'"

--- a/setup/2_database.sh
+++ b/setup/2_database.sh
@@ -9,12 +9,14 @@
 source ./0_common.sh
 
 # ---
-echo "installing packages..."
+echo "installing packages ..."
+CONFIG=""
+
 # install postgresql
 if [[ "$DISTRO" == "redhat" ]]; then
    sudo yum -y install postgresql-server
    CONFIG="/var/lib/pgsql/data/pg_hba.conf"
-elif [[ "$IDSTRO" == "ubuntu" ]]; then
+elif [[ "$DISTRO" == "ubuntu" ]]; then
    sudo apt install -y postgresql postgresql-contrib
    CONFIG="/etc/postgresql/10/main/pg_hba.conf"
 elif [[ "$DISTRO" == "archlinux" ]]; then
@@ -31,23 +33,25 @@ if [[ "$DISTRO" == "archlinux" ]]; then
     sudo -u postgres initdb -D '/var/lib/postgres/data'
 elif [[ "$DISTRO" == "MacOS" ]]; then
     initdb /usr/local/var/postgres
+elif [[ "$DISTRO" == "redhat" ]]; then
+    echo "FIXME: initdb?"
 else
-    sudo -u postgres postgresql-setup initdb
+    echo "initdb should not be needed on this platform"
 fi
 
 # ----
-echo "configuring security at $CONFIG..."
+echo "configuring security at ${CONFIG} ..."
 
 # configure PostgreSQL security to allow the postgres account in locally, and allow
 # password access remotely.  You can tweak this if you want but must choose something
 # that will work with the /etc/vespene/settings.d/database.py that will be created.
 # Using password auth is highly recommended as the workers also use database access.
-sudo tee -a $CONFIG > /dev/null <<END_OF_CONF
+sudo tee $CONFIG > /dev/null <<END_OF_CONF
 local	all	${DB_USER}	ident
 host	all	all	0.0.0.0/0	md5
 END_OF_CONF
 
-chown $DB_USER $CONFIG
+sudo chown $DB_USER $CONFIG
 
 # ---
 echo "starting postgresql..."

--- a/setup/3_application.sh
+++ b/setup/3_application.sh
@@ -12,14 +12,12 @@
 # load common settings
 source ./0_common.sh
 
-mkdir -p /etc/vespene/settings.d/
-
 cd /opt/vespene
 echo $PYTHON
-$PYTHON manage.py generate_secret
+sudo $PYTHON manage.py generate_secret
 
 # application database config
-cat >/etc/vespene/settings.d/database.py <<END_OF_DATABASES
+sudo tee -a /etc/vespene/settings.d/database.py >/dev/null <<END_OF_DATABASES
 DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
@@ -32,8 +30,9 @@ DATABASES = {
 }
 END_OF_DATABASES
 
+
 # worker configuration settings
-cat > /etc/vespene/settings.d/workers.py << END_OF_WORKERS
+sudo tee -a /etc/vespene/settings.d/workers.py >/dev/null << END_OF_WORKERS
 BUILD_ROOT="$BUILD_ROOT"
 # FILESERVING_ENABLED = True
 # FILESERVING_PORT = 8000
@@ -41,13 +40,16 @@ BUILD_ROOT="$BUILD_ROOT"
 END_OF_WORKERS
 
 # ui settings
-cat > /etc/vespene/settings.d/interface.py << END_OF_INTERFACE
+sudo tee -a /etc/vespene/settings.d/interface.py >/dev/null << END_OF_INTERFACE
 BUILDROOT_WEB_LINK="$BUILDROOT_WEB_LINK"
 END_OF_INTERFACE
+
+# ensure app user can read all of this
+echo sudo chown -R $APP_USER /etc/vespene
 
 # apply database tables
 # this only has to be run once but won't hurt anything by doing
 # it more than once. You also need this step during upgrades.
 cd /opt/vespene
-$PYTHON manage.py migrate
+$APP_SUDO $PYTHON manage.py migrate
 

--- a/setup/3_application.sh
+++ b/setup/3_application.sh
@@ -17,7 +17,7 @@ echo $PYTHON
 sudo $PYTHON manage.py generate_secret
 
 # application database config
-sudo tee -a /etc/vespene/settings.d/database.py >/dev/null <<END_OF_DATABASES
+sudo tee /etc/vespene/settings.d/database.py >/dev/null <<END_OF_DATABASES
 DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',
@@ -32,7 +32,7 @@ END_OF_DATABASES
 
 
 # worker configuration settings
-sudo tee -a /etc/vespene/settings.d/workers.py >/dev/null << END_OF_WORKERS
+sudo tee /etc/vespene/settings.d/workers.py >/dev/null << END_OF_WORKERS
 BUILD_ROOT="$BUILD_ROOT"
 # FILESERVING_ENABLED = True
 # FILESERVING_PORT = 8000
@@ -40,7 +40,7 @@ BUILD_ROOT="$BUILD_ROOT"
 END_OF_WORKERS
 
 # ui settings
-sudo tee -a /etc/vespene/settings.d/interface.py >/dev/null << END_OF_INTERFACE
+sudo tee /etc/vespene/settings.d/interface.py >/dev/null << END_OF_INTERFACE
 BUILDROOT_WEB_LINK="$BUILDROOT_WEB_LINK"
 END_OF_INTERFACE
 

--- a/setup/4_superuser.sh
+++ b/setup/4_superuser.sh
@@ -10,4 +10,5 @@ source ./0_common.sh
 
 # run the django management command (this is interactive)
 cd /opt/vespene
-$PYTHON manage.py createsuperuser
+
+$APP_SUDO $PYTHON manage.py createsuperuser

--- a/setup/5_tutorial.sh
+++ b/setup/5_tutorial.sh
@@ -13,6 +13,6 @@ source ./0_common.sh
 
 # run the custom management command that creates the objects
 cd /opt/vespene
-$PYTHON manage.py tutorial_setup
+$APP_SUDO $PYTHON manage.py tutorial_setup
 
 

--- a/setup/6_services.sh
+++ b/setup/6_services.sh
@@ -34,17 +34,16 @@ fi
 # ---
 # generate systemd init script
 
-sudo tee /etc/systemd/system/vespene.service </dev/null <<END_OF_SYSTEMD
+sudo tee /etc/systemd/system/vespene.service >/dev/null <<END_OF_SYSTEMD
 [Unit]
 Description=Vespene Services
 Documentation=http://vespene.io
 After=postgresql.service
 
 [Service]
-Type=Simple
 ExecStart=/usr/bin/supervisord -n -c /etc/vespene/supervisord.conf
-#ExecStop=/usr/bin/supervisorctl $OPTIONS shutdown
-#ExecReload=/usr/bin/supervisorctl -c /etc/vespene/supervisord.conf $OPTIONS reload
+ExecStop=/usr/bin/supervisorctl $OPTIONS shutdown
+ExecReload=/usr/bin/supervisorctl -c /etc/vespene/supervisord.conf $OPTIONS reload
 KillMode=process
 Restart=on-failure
 RestartSec=50s

--- a/setup/6_services.sh
+++ b/setup/6_services.sh
@@ -18,8 +18,7 @@ mkdir -p /var/log/vespene
 # generate the supervisor configuration
 echo "generating supervisor config..."
 cd /opt/vespene
-$PYTHON manage.py generate_supervisor --path /etc/vespene/supervisord.conf --workers "$WORKER_CONFIG" --executable=$PYTHON --source /opt/vespene
-
+$PYTHON manage.py generate_supervisor --path /etc/vespene/supervisord.conf --workers "$WORKER_CONFIG" --executable=$PYTHON --source /opt/vespene --gunicorn "$GUNICORN_OPTS"
 echo "creating init script..."
 # generate systemd init script
 cat > /etc/systemd/system/vespene.service << 'END_OF_SYSTEMD'

--- a/setup/6_services.sh
+++ b/setup/6_services.sh
@@ -34,16 +34,17 @@ fi
 # ---
 # generate systemd init script
 
-sudo tee -a /etc/systemd/system/vespene.service </dev/null<<END_OF_SYSTEMD
+sudo tee /etc/systemd/system/vespene.service </dev/null <<END_OF_SYSTEMD
 [Unit]
 Description=Vespene Services
 Documentation=http://vespene.io
 After=postgresql.service
 
 [Service]
+Type=Simple
 ExecStart=/usr/bin/supervisord -n -c /etc/vespene/supervisord.conf
-ExecStop=/usr/bin/supervisorctl $OPTIONS shutdown
-ExecReload=/usr/bin/supervisorctl -c /etc/vespene/supervisord.conf $OPTIONS reload
+#ExecStop=/usr/bin/supervisorctl $OPTIONS shutdown
+#ExecReload=/usr/bin/supervisorctl -c /etc/vespene/supervisord.conf $OPTIONS reload
 KillMode=process
 Restart=on-failure
 RestartSec=50s
@@ -59,4 +60,4 @@ sudo systemctl daemon-reload
 sudo systemctl start vespene.service
 sudo systemctl enable vespene.service
 
-echo "Vespene is now running on port 8000 and also running workers: $WORKER_CONFIG"
+echo "Vespene is now running on port 8000"

--- a/vespene/management/commands/generate_supervisor.py
+++ b/vespene/management/commands/generate_supervisor.py
@@ -27,7 +27,7 @@ minprocs=200
 
 WEB = """
 [program:server]
-command=gunicorn --bind 0.0.0.0:8000 vespene.wsgi 
+command=gunicorn %s vespene.wsgi 
 process_name=%s
 directory=%s
 autostart=true
@@ -50,8 +50,8 @@ stdout_logfile = /var/log/vespene/worker_%s.log
 stdout_logfile_maxbytes=50MB
 """
 
-# USAGE: manage.py generate_supervisor --path /etc/vespene/supervisord.conf --workers "name1=2 name2=5" --executable `which python` --source=/opt/vespene
-
+# USAGE: manage.py generate_supervisor --path /etc/vespene/supervisord.conf --workers "name1=2 name2=5" \
+#        --executable `which python` --source=/opt/vespene --gunicorn "--bind 127.0.0.1:8000"
 LOG = Logger()
 
 class Command(BaseCommand):
@@ -62,13 +62,15 @@ class Command(BaseCommand):
         parser.add_argument('--workers', type=str, help="what workers to run?")
         parser.add_argument('--executable', type=str, help="python executable")
         parser.add_argument('--source', type=str, help='source')
+        parser.add_argument('--gunicorn", type=str, help='gnuicorn options string', default='--bind 127.0.0.1:8000"
 
     def handle(self, *args, **options):
 
         path = options.get('path', None)
         workers = options.get('workers', None)
         python = options.get('executable', None)
-        source = options.get('source', '/opt/vespene/')
+        source = options.get('source', None)
+        gunicorn = options.get('gunicorn', None)
 
         if not workers and not "=" in workers:
             raise CommandError("worker configuration does not look correct")
@@ -80,7 +82,7 @@ class Command(BaseCommand):
         fd = open(path, "w+")
         fd.write(PREAMBLE)
         fd.write("\n")
-        fd.write(WEB % ("%(program_name)s", source))
+        fd.write(WEB % (gunicorn, "%(program_name)s", source))
         fd.write("\n")
 
         for worker in workers:

--- a/vespene/management/commands/generate_supervisor.py
+++ b/vespene/management/commands/generate_supervisor.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         parser.add_argument('--workers', type=str, help="what workers to run?")
         parser.add_argument('--executable', type=str, help="python executable")
         parser.add_argument('--source', type=str, help='source')
-        parser.add_argument('--gunicorn", type=str, help='gnuicorn options string', default='--bind 127.0.0.1:8000"
+        parser.add_argument('--gunicorn', type=str, help='gnuicorn options string', default='--bind 127.0.0.1:8000')
 
     def handle(self, *args, **options):
 


### PR DESCRIPTION
This is an update to the setup process so that on most Linux/Unix systems the main processes run as a "vespene" user.

This also incorporates OS X setup (so you can skip the dev instructions if you want) that run most everything as the main user who is logged in.

All of these changes require that a non-priveledged user run the setup, no longer "sudo bash <script>", and the result is that these will sudo a fair amount inside the scripts.

I'm quite open to improvements here, this is a little rough, but seems to work fine on OS X, CentOS 7, and Ubuntu Bionic.

If there are any problems I'll fix them quickly.