### PR TITLE
make text areas and inputs selectable in Build -> Output tab (fixes #69)

### DIFF
--- a/vespene/views/forms.py
+++ b/vespene/views/forms.py
@@ -37,8 +37,12 @@ class BaseForm(forms.ModelForm):
         super(BaseForm, self).__init__(*args, **kwargs)
 
     def make_read_only(self):
+        template_names = ['django/forms/widgets/text.html', 'django/forms/widgets/textarea.html']
         for x in self.Meta.fields:
-            self.fields[x].widget.attrs['disabled'] = True
+            if self.fields[x].widget.template_name in template_names:
+                self.fields[x].widget.attrs['readonly'] = True
+            else:
+                self.fields[x].widget.attrs['disabled'] = True
         return self
 
 class StageForm(BaseForm):


### PR DESCRIPTION
This only affects input fields and textareas and makes them `readonly` instead of `disabled`. All the other fields remain `disabled` since making a dropdown field `readonly` gives the illusion that you can actually select something.

As mentioned in the title, this fixes issue #69 