### PR TITLE
centralize postgresql inside the dedicated database setup script

### DIFF
--- a/setup/1_prepare.sh
+++ b/setup/1_prepare.sh
@@ -11,21 +11,16 @@ if [ "$DISTRO" == "redhat" ]; then
     # on Red Hat
     # sudo yum-config-manager --enable rhel-server-rhscl-7-rpms ?
     sudo yum -y install epel-release
-    sudo yum -y install gcc python36 python36-devel supervisor rh-postgresql10
+    sudo yum -y install gcc python36 python36-devel supervisor
     sudo python36 -m ensurepip
-    sudo tee /etc/profile.d/enable_pg10.sh >/dev/null << END_OF_PG10
-    #!/bin/bash
-    source scl_source enable rh-postgresql10
-END_OF_PG10
-    sudo chmod +x /etc/profile.d/enable_pg10.sh 
 elif [ "$DISTRO" == "ubuntu" ]; then
     sudo apt-add-repository universe
     sudo apt-get update
-    sudo apt-get install -y gcc libssl-dev postgresql-client python3 python3-pip python3-setuptools supervisor
+    sudo apt-get install -y gcc libssl-dev python3 python3-pip python3-setuptools supervisor
 elif [ "$DISTRO" == "archlinux" ]; then
-    sudo pacman --noconfirm -Sy python python-pip python-setuptools postgresql supervisor sudo
+    sudo pacman --noconfirm -Sy python python-pip python-setuptools  supervisor sudo
 elif [ "$DISTRO" == "MacOS" ]; then
-    brew install python@3 postgresql supervisor
+    brew install python@3 supervisor
 fi
 
 if [ "$DISTRO" != "MacOS" ]; then

--- a/setup/2_database.sh
+++ b/setup/2_database.sh
@@ -15,17 +15,28 @@ PG_PREFIX=""
 
 # install postgresql
 if [[ "$DISTRO" == "redhat" ]]; then
-   # use software collections
-   PG_PREFIX="/opt/rh/rh-postgresql10/root/usr/bin/"
-   CONFIG="/var/opt/rh/rh-postgresql10/lib/pgsql/data/pg_hba.conf"
+    # this just covers CentOS for now
+    sudo yum -y install centos-release-scl
+    # on Red Hat
+    # use software collections
+    sudo yum -y install epel-release
+    sudo yum -y install rh-postgresql10
+    sudo tee /etc/profile.d/enable_pg10.sh >/dev/null << END_OF_PG10
+    #!/bin/bash
+    source scl_source enable rh-postgresql10
+END_OF_PG10
+    sudo chmod +x /etc/profile.d/enable_pg10.sh 
+    PG_PREFIX="/opt/rh/rh-postgresql10/root/usr/bin/"
+    CONFIG="/var/opt/rh/rh-postgresql10/lib/pgsql/data/pg_hba.conf"
 elif [[ "$DISTRO" == "ubuntu" ]]; then
-   sudo apt install -y postgresql postgresql-contrib
-   CONFIG="/etc/postgresql/10/main/pg_hba.conf"
+    sudo apt install -y postgresql postgresql-contrib postgresql-client
+    CONFIG="/etc/postgresql/10/main/pg_hba.conf"
 elif [[ "$DISTRO" == "archlinux" ]]; then
-   sudo pacman --noconfirm -Sy postgresql
-   CONFIG="/var/lib/postgres/data/pg_hba.conf"
+    sudo pacman --noconfirm -Sy postgresql
+    CONFIG="/var/lib/postgres/data/pg_hba.conf"
 elif [[ "$DISTRO" == "MacOS" ]]; then
-   CONFIG="/usr/local/var/postgres/pg_hba.conf"
+    brew install postgresql
+    CONFIG="/usr/local/var/postgres/pg_hba.conf"
 fi
 
 # ---


### PR DESCRIPTION
We have a script  dedicated to configure database
on dedicated node and we doesn't install postgresql inside it.

We also install a lot of unuseful dependencies like python pip
and setuptools on a database node if we need to use the
step 1_prepare on the database node.