### PR TITLE
add comma to prevent breakdown

### DIFF
--- a/setup/3_application.sh
+++ b/setup/3_application.sh
@@ -76,7 +76,7 @@ sudo tee /etc/vespene/settings.d/authentication.py >/dev/null << END_OF_AUTHENTI
 
 AUTHENTICATION_BACKENDS = (
     #'django_auth_ldap.backend.LDAPBackend',
-    'django.contrib.auth.backends.ModelBackend'
+    'django.contrib.auth.backends.ModelBackend',
 )
 END_OF_AUTHENTICATION
 


### PR DESCRIPTION
On my debian machine Django kept throwing `d doesn't look like a module path` whenever I would log in. This fixes the error, by explicitly defining `AUTHENTICATION_BACKENDS` as a tuple.

There's a Slovenian saying about commas and their importance, but I can't really translate it to english. I just want the world to know. :stuck_out_tongue: 